### PR TITLE
Set whatsapp image for home and about

### DIFF
--- a/index.html
+++ b/index.html
@@ -1316,7 +1316,7 @@
       <div class="col-12 d-flex justify-content-center mb-4">
         <div class="dynamic-photo-wrapper">
           <div class="photo-glow"></div>
-          <img src="assets/img/perfil.png" alt="Profile Photo" class="dynamic-profile-img" loading="lazy">
+          <img src="WhatsApp Image 2025-08-01 at 06.13.53_4b74e769.jpg" alt="Profile Photo" class="dynamic-profile-img" loading="lazy">
           <div class="photo-particles">
             <div class="photo-particle"></div>
             <div class="photo-particle"></div>
@@ -1363,7 +1363,7 @@
       <div class="col-lg-4 mb-4 mb-lg-0">
         <div class="profile-card">
           <div class="profile-img-container">
-            <img src="assets/img/about.jpg" alt="Alex Bennett" class="profile-img" loading="lazy">
+            <img src="WhatsApp Image 2025-08-01 at 06.13.53_4b74e769.jpg" alt="Alex Bennett" class="profile-img" loading="lazy">
             <div class="profile-img-overlay"></div>
           </div>
           <div class="profile-info">


### PR DESCRIPTION
Set WhatsApp image as the profile photo in the home and about sections.

---
<a href="https://cursor.com/background-agent?bcId=bc-81788e6a-7980-492d-9c19-6a0c32077442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81788e6a-7980-492d-9c19-6a0c32077442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>